### PR TITLE
Fix references to time-aware-polyline after name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This gem provides an implementation of the [time aware polyline](https://medium.
 ## Encoder
 ​
 ```ruby
-require 'time-aware-polyline'
+require 'time_aware_polyline'
 ​
 points = [
   [19.13626, 72.92506, '2016-07-21T05:43:09+00:00'],
@@ -19,7 +19,7 @@ TimeAwarePolyline.encode_time_aware_polyline(points)
 ## Decoder
 ​
 ```ruby
-require 'time-aware-polyline'
+require 'time_aware_polyline'
 ​
 TimeAwarePolyline.decode_time_aware_polyline('spxsBsdb|Lymo`qvAx@TKvAr@K')
 ```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'time-aware-polyline'
+require 'time_aware_polyline'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
The name of this gem was refactored from kebab case to snake case in this change, https://github.com/Root-App/time_aware_polyline/commit/3b732a657ce4ed73741c09293e713dace1c8b0e8, but there were a few references missed during the renaming.