### PR TITLE
Fix references to time-aware-polyline after name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # Time Aware Polyline
-​
+
 This gem provides an implementation of the [time aware polyline](https://medium.com/hypertrack/the-missing-dimension-in-geospatial-data-formats-78e6fcb4503d) algorithm. The time aware polyline algorithm extends the [polyline encoding algorithm](https://developers.google.com/maps/documentation/utilities/polylinealgorithm) in order to add support for timestamps.
-​
+
 ## Encoder
-​
+
 ```ruby
-require 'time-aware-polyline'
-​
+require 'time_aware_polyline'
+
 points = [
   [19.13626, 72.92506, '2016-07-21T05:43:09+00:00'],
   [19.13597, 72.92495, '2016-07-21T05:43:15+00:00'],
   [19.13553, 72.92469, '2016-07-21T05:43:21+00:00']
 ]
-​
+
 TimeAwarePolyline.encode_time_aware_polyline(points)
 ```
-​
+
 ## Decoder
-​
+
 ```ruby
-require 'time-aware-polyline'
-​
+require 'time_aware_polyline'
+
 TimeAwarePolyline.decode_time_aware_polyline('spxsBsdb|Lymo`qvAx@TKvAr@K')
 ```
-​
+
 ## Related Implementations
 - [Python](https://libraries.io/pypi/time_aware_polyline)
 - [JavaScript](https://www.npmjs.com/package/time-aware-polyline/v/0.0.2-0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'time-aware-polyline'
+require 'time_aware_polyline'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
The name of this gem was refactored from kebab case to snake case in this change, 3b732a6, but there were a few references missed during the renaming.